### PR TITLE
Fix #1: step player forward after cave entrance warp

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This is a fork of the PRET project with custom features. Development is AI-assis
 
   ![Type Effectiveness Colors](gifs/ColourizedMoves.gif)
 
-- **Walk With Pokemon** — Your pokemon follows you around in the overworld.
+- **Walk With Pokemon** — Your pokemon follows you around in the overworld. When entering a cave or dungeon, the player automatically steps one tile forward after the transition so the follower spawns at the entrance tile rather than blocking the path ahead.
 
   ![Walk With Pokemon](gifs/WalkWithPokemon.gif)
 

--- a/include/field_fadetransition.h
+++ b/include/field_fadetransition.h
@@ -34,5 +34,6 @@ bool8 FieldCB_ReturnToFieldOpenStartMenu(void);
 void FieldCB_ContinueScript(void);
 void FieldCB_ContinueScriptHandleMusic(void);
 void FieldCB_WarpExitFadeFromBlack(void);
+void SetCaveEntryWarpExitFlag(void);
 
 #endif // GUARD_FIELD_FADETRANSITION_H

--- a/include/overworld.h
+++ b/include/overworld.h
@@ -176,6 +176,7 @@ void CB1_Overworld(void);
 void CB2_ReturnToFieldContinueScript(void);
 u8 GetLastUsedWarpMapSectionId(void);
 void StoreInitialPlayerAvatarState(void);
+void SetInitialPlayerAvatarStateWithDirection(u8 dirn);
 void UpdateEscapeWarp(s16 x, s16 y);
 bool8 SetDiveWarpEmerge(u16 x, u16 y);
 bool8 SetDiveWarpDive(u16 x, u16 y);

--- a/src/field_control_avatar.c
+++ b/src/field_control_avatar.c
@@ -884,7 +884,20 @@ static bool8 TryStartWarpEventScript(struct MapPosition *position, u16 metatileB
 
     if (warpEventId != -1 && IsWarpMetatileBehavior(metatileBehavior) == TRUE)
     {
-        StoreInitialPlayerAvatarState();
+        if (MetatileBehavior_IsNonAnimDoor(metatileBehavior) == TRUE)
+        {
+            /* Cave entrance (MB_CAVE_DOOR): preserve the player's travel direction
+             * so InitPlayerAvatar faces them into the cave (not back toward the
+             * entrance). hasDirectionSet = TRUE lets GetAdjustedInitialDirection
+             * return this direction instead of the default DIR_SOUTH.
+             * SetCaveEntryWarpExitFlag tells Task_ExitNonDoor to step the player
+             * one tile forward after the fade-in, ensuring the follower spawns
+             * at the entrance tile rather than blocking the player's path. */
+            SetInitialPlayerAvatarStateWithDirection(GetPlayerFacingDirection());
+            SetCaveEntryWarpExitFlag();
+        }
+        else
+            StoreInitialPlayerAvatarState();
         SetupWarp(&gMapHeader, warpEventId, position);
         if (MetatileBehavior_IsEscalator(metatileBehavior) == TRUE)
         {

--- a/src/field_fadetransition.c
+++ b/src/field_fadetransition.c
@@ -59,6 +59,17 @@
 #include "constants/event_objects.h"
 #include "constants/field_weather.h"
 
+/* Set by TryStartWarpEventScript when entering via MB_CAVE_DOOR (NonAnimDoor
+ * source tile, e.g. a cave entrance on a route). Task_ExitNonDoor reads this
+ * via task->data[1] and queues a step-forward so the player walks into the
+ * cave rather than stopping at the warp landing tile. */
+static bool8 sCaveEntryWarpExit;
+
+void SetCaveEntryWarpExitFlag(void)
+{
+    sCaveEntryWarpExit = TRUE;
+}
+
 static void ExitWarpFadeInScreen(u8 playerNotMoving);
 static void Task_ExitDoor(u8 taskId);
 static void Task_ExitNonAnimDoor(u8 taskId);
@@ -504,7 +515,16 @@ static void SetUpWarpExitTask(bool8 playerNotMoving)
             func = Task_ExitNonDoor;     /* Simple appear-and-fade */
     }
     gExitStairsMovementDisabled = FALSE;
-    CreateTask(func, 10);
+    {
+        /* Consume the cave-entry flag immediately so it can't bleed into
+         * subsequent warps if something goes wrong before the task runs. */
+        bool8 shouldStep = sCaveEntryWarpExit;
+        u8 taskId;
+        sCaveEntryWarpExit = FALSE;
+        taskId = CreateTask(func, 10);
+        if (shouldStep)
+            gTasks[taskId].data[1] = 1;
+    }
 }
 
 /**
@@ -765,27 +785,61 @@ static void Task_ExitNonAnimDoor(u8 taskId)
 /**
  * FUNCTION: Task_ExitNonDoor
  *
- * PURPOSE: Simplest warp exit — just freeze, wait for fade, then unfreeze.
- * Used for cave entrances, ladders, and other non-door warps.
+ * PURPOSE: Warp exit for boundary warps (route transitions) and directional-stair
+ * warps when stair movement is disabled. Waits for the fade-in to finish, then
+ * unfreezes object events and unlocks player controls.
+ *
+ * When data[1] is set (cave-entry warp from a NonAnimDoor source tile), adds two
+ * extra states that walk the player one tile forward in their facing direction.
+ * This ensures the follower spawns behind the player rather than in the path
+ * the player needs to walk.
+ *
+ * State 0: Freeze NPCs and lock player input.
+ * State 1: Wait for fade to finish; start walk if data[1] set, else finish.
+ * State 2 (cave only): Wait for walk to complete.
+ * State 3 (cave only): Unfreeze and unlock.
  *
  * @param taskId — task identifier
  */
 static void Task_ExitNonDoor(u8 taskId)
 {
-    switch (gTasks[taskId].data[0])
+    struct Task *task = &gTasks[taskId];
+    switch (task->data[0])
     {
     case 0:
         FreezeObjectEvents();
         LockPlayerFieldControls();
-        gTasks[taskId].data[0]++;
+        task->data[0]++;
         break;
     case 1:
         if (FieldFadeTransitionBackgroundEffectIsFinished())
         {
-            UnfreezeObjectEvents();
-            UnlockPlayerFieldControls();
-            DestroyTask(taskId);
+            if (task->data[1])
+            {
+                /* Cave entry: step player one tile in their facing direction.
+                 * ObjectEventSetHeldMovement unfreezes the player OE so the walk
+                 * proceeds while all other OEs remain frozen. */
+                ObjectEventSetHeldMovement(
+                    &gObjectEvents[GetObjectEventIdByLocalIdAndMap(LOCALID_PLAYER, 0, 0)],
+                    GetWalkNormalMovementAction(GetPlayerFacingDirection()));
+                task->data[0] = 2;
+            }
+            else
+            {
+                UnfreezeObjectEvents();
+                UnlockPlayerFieldControls();
+                DestroyTask(taskId);
+            }
         }
+        break;
+    case 2:
+        if (walkrun_is_standing_still())
+            task->data[0] = 3;
+        break;
+    case 3:
+        UnfreezeObjectEvents();
+        UnlockPlayerFieldControls();
+        DestroyTask(taskId);
         break;
     }
 }

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -884,7 +884,7 @@ void ResetInitialPlayerAvatarState(void)
     sInitialPlayerAvatarState.hasDirectionSet = FALSE;
 }
 
-static void SetInitialPlayerAvatarStateWithDirection(u8 dirn)
+void SetInitialPlayerAvatarStateWithDirection(u8 dirn)
 {
     sInitialPlayerAvatarState.direction = dirn;
     sInitialPlayerAvatarState.transitionFlags = PLAYER_AVATAR_FLAG_ON_FOOT;

--- a/test/lib/warp.lua
+++ b/test/lib/warp.lua
@@ -134,8 +134,13 @@ function warp.warp_to_pos(map_group, map_num, x, y)
     emu:write16(warp.S_WARP_DESTINATION + 4, x)
     emu:write16(warp.S_WARP_DESTINATION + 6, y)
 
-    -- 2. Apply to SaveBlock1->location.
+    -- 2. Apply to SaveBlock1->location AND pos.
+    --    CB2_LoadMap bypasses WarpIntoMap/SetPlayerCoordsFromWarp, so pos is
+    --    never updated from location. Write pos directly so InitPlayerAvatar
+    --    (via GetCameraFocusCoords) places the OE at the correct tile.
     local sb1 = fw.read32(ADDR.gSaveBlock1Ptr)
+    emu:write16(sb1 + 0x00, x)  -- SaveBlock1.pos.x
+    emu:write16(sb1 + 0x02, y)  -- SaveBlock1.pos.y
     emu:write8(sb1 + ADDR.SB1_LOC_MAP_GROUP, map_group)
     emu:write8(sb1 + ADDR.SB1_LOC_MAP_NUM,   map_num)
     emu:write8(sb1 + 0x06,                   WARP_ID_NONE)

--- a/test/tests/test_cave_entry_step.lua
+++ b/test/tests/test_cave_entry_step.lua
@@ -1,0 +1,288 @@
+-------------------------------------------------------------------------------
+-- test_cave_entry_step.lua
+--
+-- Verifies that when the player walks into a cave entrance warp, they
+-- automatically step one tile forward after the transition (Task_ExitNonDoor
+-- must queue a WALK_NORMAL movement after the fade-in).
+--
+-- Without the fix: Task_ExitNonDoor only fades in and unlocks — no step.
+-- With the fix:    Task_ExitNonDoor queues GetWalkNormalMovementAction(facing)
+--                  after the fade, identical to Task_ExitNonAnimDoor.
+--
+-- SCENARIO:
+--   Route 4 warpId=0 tile at (19, 5) → MAP_MT_MOON_1F warpId=3 lands
+--   the player at (18, 37) inside Mt. Moon 1F, facing NORTH (into the cave).
+--   After the fix the player ends up at (18, 36).
+--
+-- Part A — no follower: confirms the step-forward itself.
+-- Part B — Pikachu follower via WALK menu: confirms follower spawns at the
+--   entrance tile (18, 37) and is NOT stacked on the player after the step.
+--
+-- FIXTURE STATE (self-healing):
+--   Boots through Oak's speech to the overworld, warps to Route 4 warpId=0
+--   (the cave entrance tile at (19,5)) via warp_to. Saved to
+--   /tmp/pokefirered-cave-entry-step.ss. Delete to recreate after a ROM
+--   rebuild that shifts EWRAM symbol addresses.
+--
+-- Run:    bash test/run_test.sh  test/tests/test_cave_entry_step.lua
+-- Record: bash test/record_test.sh test/tests/test_cave_entry_step.lua
+-------------------------------------------------------------------------------
+
+local script_dir = debug.getinfo(1, "S").source:match("@?(.*/)") or ""
+local project_dir = script_dir .. "../../"
+local fw   = dofile(project_dir .. "test/lib/framework.lua")
+local cs   = dofile(project_dir .. "test/lib/character_select.lua")
+local warp = dofile(project_dir .. "test/lib/warp.lua")
+local ADDR = dofile(project_dir .. "test/lib/addresses.lua")
+
+local STATE_PATH  = "/tmp/pokefirered-cave-entry-step.ss"
+local PARTY_BASE  = 0x02024284   -- gPlayerParty
+local POKEMON_SIZE = 100
+
+-- MAP_MT_MOON_1F = (1 | (1 << 8)) → mapGroup=1, mapNum=1
+local MT_MOON_MAP_GROUP = 1
+local MT_MOON_MAP_NUM   = 1
+-- Route 4 warpId=0 lands the player at Mt Moon 1F warpId=3.
+-- OE coords = map tile + MAP_OFFSET(7); SetPlayerCoordsFromWarp reads
+-- ROM warp[3] = (18,37), so OE = (25,44).
+local WARP_LAND_X = 25  -- OE x of map tile (18,37): entrance tile
+local WARP_LAND_Y = 44  -- OE y of map tile (18,37)
+-- After one step north (map tile (18,36)): OE = (25,43).
+local STEP_X = 25   -- OE x of map tile (18,36)
+local STEP_Y = 43   -- OE y of map tile (18,36)
+
+-- MAP_ROUTE4 = (22 | (3 << 8)) → mapGroup=3, mapNum=22
+local ROUTE4_MAP_GROUP = 3
+local ROUTE4_MAP_NUM   = 22
+-- Route 4 warpId=0 is the cave entrance tile (19,5).
+-- We place the player HERE via warp_to, step south off it, then step
+-- back north onto it so TryArrowWarp fires naturally.
+local CAVE_WARP_ID = 0
+
+local SPECIES_PIKACHU  = 25
+local LOCALID_FOLLOWER = 254   -- include/constants/event_objects.h
+
+-- ------------------------------------------------------------------ --
+-- Helpers
+-- ------------------------------------------------------------------ --
+
+local function inject_pokemon(base, species, level)
+    for i = 0, POKEMON_SIZE - 1 do
+        emu:write8(base + i, 0)
+    end
+    emu:write8(base + 0x13, 0x02)                              -- hasSpecies flag
+    emu:write8(base + 0x55, 0xFF)                              -- no mail
+    emu:write8(base + 0x20, species % 256)                     -- species low byte
+    emu:write8(base + 0x21, math.floor(species / 256))         -- species high byte
+    -- Checksum = sum of all 24 u16s in secure.raw. Only species is non-zero.
+    emu:write8(base + 0x1C, species % 256)
+    emu:write8(base + 0x1D, math.floor(species / 256))
+    emu:write8(base + 0x54, level)   -- level
+    emu:write8(base + 0x56, 20)      -- currentHP low
+    emu:write8(base + 0x57, 0)
+    emu:write8(base + 0x58, 20)      -- maxHP low
+    emu:write8(base + 0x59, 0)
+end
+
+local function read_player_coords()
+    local pa   = fw.read8(ADDR.gPlayerAvatar + ADDR.PA_OBJECT_EVENT_ID)
+    local base = ADDR.gObjectEvents + pa * ADDR.OBJECT_EVENT_SIZE
+    return fw.read16(base + ADDR.OE_CURRENT_X),
+           fw.read16(base + ADDR.OE_CURRENT_Y)
+end
+
+-- Scan gObjectEvents for the follower ObjectEvent (LOCALID_FOLLOWER = 254).
+-- Returns (x, y) or (nil, nil) if not found.
+local function find_follower_coords()
+    for i = 0, 15 do
+        local base = ADDR.gObjectEvents + i * ADDR.OBJECT_EVENT_SIZE
+        local lid  = fw.read8(base + ADDR.OE_LOCAL_ID)
+        if lid == LOCALID_FOLLOWER then
+            return fw.read16(base + ADDR.OE_CURRENT_X),
+                   fw.read16(base + ADDR.OE_CURRENT_Y)
+        end
+    end
+    return nil, nil
+end
+
+local function current_map()
+    local sb1 = fw.read32(ADDR.gSaveBlock1Ptr)
+    return fw.read8(sb1 + ADDR.SB1_LOC_MAP_GROUP),
+           fw.read8(sb1 + ADDR.SB1_LOC_MAP_NUM)
+end
+
+-- Enter the cave: player is at Route 4, at most 3 tiles south of (19,5).
+-- Hold UP long enough to walk north to (19,5) and trigger the warp.
+-- At 16 frames/tile, 48 frames handles 3 tiles with headroom.
+-- FreezeObjectEvents stops the player as soon as the warp fires, so
+-- holding UP past the warp trigger is harmless.
+--
+-- After the hold, the Route→Underground transition plays the cave preview
+-- screen (FlashTransition_Enter → MapPreviewScreen task). This blocks
+-- InitObjectEventsLocal until the player dismisses it with A. We press A
+-- repeatedly to dismiss both the preview and any post-warp dialogue, then
+-- wait for the map load + Task_ExitNonDoor fade-in to complete.
+local function enter_cave()
+    fw.log("Holding UP to walk into cave entrance at (19,5)...")
+    fw.hold("UP", 48)
+    -- Fade and cave transition animation run (~60f).
+    fw.wait_frames(80)
+    -- Dismiss cave preview screen (and any follow-on dialogue).
+    for _ = 1, 10 do
+        fw.press("A")
+        fw.wait_frames(20)
+    end
+    -- Map load + Task_ExitNonDoor step-forward (~16f extra).
+    fw.wait_frames(120)
+end
+
+local results = {}
+local function check(name, cond)
+    results[#results + 1] = {name = name, pass = cond}
+    fw.log((cond and "[PASS] " or "[FAIL] ") .. name)
+end
+
+-- ------------------------------------------------------------------ --
+fw.run(function()
+    fw.log("=== Cave Entry Step-Forward Test ===")
+
+    -- ------------------------------------------------------------------ --
+    -- Fixture: place player ON the cave entrance tile (Route 4 warpId=0)
+    -- ------------------------------------------------------------------ --
+    if not fw.try_load_state(STATE_PATH) then
+        fw.log("No cached state — booting to overworld...")
+        local sel = cs.find_selection_press()
+        if not sel then
+            fw.log("ERROR: character select discovery failed — aborting")
+            fw.finish()
+            return
+        end
+        emu:reset()
+        cs.boot_and_open_list(sel)
+        cs.confirm_and_enter_overworld()
+        fw.log("Reached overworld. Warping to Route 4 (19,6) — one tile south of cave entrance...")
+        -- Place player at (19,6) — one tile south of the cave warp at (19,5).
+        -- warp_to_pos writes pos directly so InitPlayerAvatar lands at the
+        -- correct tile (CB2_LoadMap bypasses SetPlayerCoordsFromWarp).
+        warp.warp_to_pos(ROUTE4_MAP_GROUP, ROUTE4_MAP_NUM, 19, 6)
+        fw.save_state(STATE_PATH)
+    end
+    fw.wait_frames(60)
+
+    -- ================================================================== --
+    -- Part A: No follower — verify player steps one tile forward on entry
+    -- ================================================================== --
+    fw.log("--- Part A: No follower ---")
+
+    enter_cave()
+
+    local mg, mn = current_map()
+    check("Part A: warped into Mt. Moon 1F (mapGroup=1, mapNum=1)",
+          mg == MT_MOON_MAP_GROUP and mn == MT_MOON_MAP_NUM)
+
+    local post_pa   = fw.read8(ADDR.gPlayerAvatar + ADDR.PA_OBJECT_EVENT_ID)
+    local post_base = ADDR.gObjectEvents + post_pa * ADDR.OBJECT_EVENT_SIZE
+    local px, py = fw.read16(post_base + ADDR.OE_CURRENT_X), fw.read16(post_base + ADDR.OE_CURRENT_Y)
+    check("Part A: player stepped forward to map(18,36)",
+          px == STEP_X and py == STEP_Y)
+
+    -- ================================================================== --
+    -- Part B: With Pikachu follower (activated via WALK menu)
+    --         Verify follower spawns at entrance tile (18,37), not on
+    --         player's tile (18,36).
+    -- ================================================================== --
+    fw.log("--- Part B: Pikachu follower via WALK menu ---")
+
+    -- Reload fixture (clean state, no follower)
+    fw.try_load_state(STATE_PATH)
+    fw.wait_frames(60)
+
+    -- Inject Pikachu into party slot 0 and set FLAG_SYS_POKEMON_GET so
+    -- the Start menu shows the POKEMON option.
+    inject_pokemon(PARTY_BASE, SPECIES_PIKACHU, 5)
+    emu:write8(ADDR.gPlayerPartyCount, 1)
+    -- FLAG_SYS_POKEMON_GET = 0x828 → byte index 0x105, bit 0.
+    -- Do NOT set FLAG_SYS_POKEDEX_GET (0x829); it would push POKEDEX to
+    -- index 0 and we'd select the wrong menu entry.
+    local sb1 = fw.read32(ADDR.gSaveBlock1Ptr)
+    local flag_addr = sb1 + ADDR.SB1_FLAGS + math.floor(0x828 / 8)
+    emu:write8(flag_addr, fw.read8(flag_addr) | 0x01)
+    fw.wait_frames(10)
+
+    -- Open Start menu → POKEMON (index 0) → party slot 0 (Pikachu) → WALK
+    -- Action menu for Pikachu (alone, no HMs): SUMMARY(0) WALK(1) ITEM(2)
+    --   MOVE_TO_PC(3) CANCEL(4). Cursor starts at 0; one DOWN reaches WALK.
+    fw.press("START")
+    fw.wait_frames(80)
+    fw.press("A")          -- select POKEMON
+    fw.wait_frames(120)
+    fw.press("A")          -- open action menu for slot 0
+    fw.wait_frames(80)
+    fw.press("DOWN")       -- move cursor from SUMMARY(0) to WALK(1)
+    fw.wait_frames(20)
+    fw.press("A")          -- confirm WALK → ActivateFollower, close party menu
+    fw.wait_frames(150)    -- wait for CB2_ReturnToField + follower spawn
+
+    -- Re-position on Route 4 cave entrance via programmatic warp so Part A's
+    -- cave-exit state doesn't bleed in. Follower re-spawns on map load.
+    -- Use warp_to_pos (not warp_to) so SaveBlock1->pos is set correctly;
+    -- warp_to with a warpId skips SetPlayerCoordsFromWarp and leaves pos stale.
+    fw.log("Re-warping to Route 4 (19,6) starting position...")
+    warp.warp_to_pos(ROUTE4_MAP_GROUP, ROUTE4_MAP_NUM, 19, 6)
+    fw.wait_frames(60)
+    -- The follower initialises 1 tile north of the player (at the cave warp
+    -- tile) when spawned via programmatic warp. This blocks northward movement.
+    -- Move it directly to (19,7) = OE(26,14) — one tile south of the player —
+    -- so the approach is clear. previousCoords is also rewritten to avoid a
+    -- one-frame snap back.
+    local OE_PREV_X = 0x14   -- previousCoords.x (see OE struct comment in addresses.lua)
+    local OE_PREV_Y = 0x16   -- previousCoords.y
+    for i = 0, 15 do
+        local oe = ADDR.gObjectEvents + i * ADDR.OBJECT_EVENT_SIZE
+        if fw.read8(oe + ADDR.OE_LOCAL_ID) == LOCALID_FOLLOWER then
+            emu:write16(oe + ADDR.OE_CURRENT_X, 26)  -- OE x = 19 + MAP_OFFSET(7)
+            emu:write16(oe + ADDR.OE_CURRENT_Y, 14)  -- OE y = 7  + MAP_OFFSET(7)
+            emu:write16(oe + OE_PREV_X,          26)
+            emu:write16(oe + OE_PREV_Y,          15)  -- one further south
+            break
+        end
+    end
+    fw.wait_frames(10)
+
+    enter_cave()
+
+    local mg2, mn2 = current_map()
+    check("Part B: warped into Mt. Moon 1F",
+          mg2 == MT_MOON_MAP_GROUP and mn2 == MT_MOON_MAP_NUM)
+
+    local px2, py2 = read_player_coords()
+    fw.log(string.format("Player OE: (%d,%d) [map(%d,%d)]  expected OE: (%d,%d)", px2, py2, px2-7, py2-7, STEP_X, STEP_Y))
+    check("Part B: player stepped forward to map(18,36)", px2 == STEP_X and py2 == STEP_Y)
+
+    local fx, fy = find_follower_coords()
+    if fx then
+        fw.log(string.format("Follower OE: (%d,%d) [map(%d,%d)]", fx, fy, fx-7, fy-7))
+        -- The follower must not be directly north of the player's landing tile
+        -- (the original bug: follower spawned at (18,36), blocking the step north
+        -- from (18,37)). The fix ensures "behind" (south) is tried first; since
+        -- the cave wall is south, the follower ends up to the side, not north.
+        check("Part B: follower not blocking cave entry (not directly north of landing)",
+              not (fx == WARP_LAND_X and fy < WARP_LAND_Y))
+        check("Part B: follower not stacked on player after step",
+              not (fx == px2 and fy == py2))
+    else
+        fw.log("[FAIL] Part B: follower ObjectEvent not found")
+        results[#results + 1] = {name = "Part B: follower spawned", pass = false}
+        results[#results + 1] = {name = "Part B: follower not stacked on player", pass = false}
+    end
+
+    -- ================================================================== --
+    -- Summary
+    -- ================================================================== --
+    local passed = 0
+    for _, r in ipairs(results) do
+        if r.pass then passed = passed + 1 end
+    end
+    fw.log(string.format("Results: %d/%d passed", passed, #results))
+    fw.finish()
+end)


### PR DESCRIPTION
## Summary

- When entering a cave via a `MB_CAVE_DOOR` source tile (e.g. Route 4 → Mt. Moon), the player now automatically steps one tile into the cave after the fade-in
- This ensures the follower Pokémon spawns at the entrance tile rather than blocking the player's path into the cave
- 6/6 automated tests passing in `test/tests/test_cave_entry_step.lua`

## What changed

**`src/field_control_avatar.c`**: In `TryStartWarpEventScript`, detect `MB_CAVE_DOOR` (NonAnimDoor) source tiles and call `SetInitialPlayerAvatarStateWithDirection(GetPlayerFacingDirection())` + `SetCaveEntryWarpExitFlag()` instead of `StoreInitialPlayerAvatarState()`. This sets `hasDirectionSet = TRUE` with the player's travel direction (e.g. `DIR_NORTH`) so the player faces into the cave on arrival.

**`src/field_fadetransition.c`**: Added a static `sCaveEntryWarpExit` flag consumed in `SetUpWarpExitTask` (stored in `task->data[1]`). `Task_ExitNonDoor` grows two conditional states: if `data[1]` is set, the player walks one step in their facing direction and waits for it to complete before unfreezing. All other route boundary warps (no flag set) are unchanged.

**`test/tests/test_cave_entry_step.lua`**: New test: Part A verifies solo player steps to map(18,36); Part B verifies follower-with-Pikachu doesn't block the player after entry.

**`test/lib/warp.lua`**: Fixed `warp_to_pos` to also write `SaveBlock1.pos` so `InitPlayerAvatar` places the player at the correct tile (needed for the test fixture).

## Test plan

- [x] Part A (no follower): player warps into Mt. Moon 1F, player steps to map(18,36) ✓
- [x] Part B (Pikachu follower): player steps to map(18,36), follower not blocking ✓
- [x] Build clean with `make -j$(nproc) firered` ✓

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)