### PR TITLE
Fix #4: track walking pokemon by species+PID, not party slot index

### DIFF
--- a/docs/superpowers/plans/2026-04-26-walking-pokemon-return-fix.md
+++ b/docs/superpowers/plans/2026-04-26-walking-pokemon-return-fix.md
@@ -1,0 +1,547 @@
+# Walking Pokemon Return Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the party-menu RETURN option to identify the walking Pokemon by species+PID rather than by party slot index, so rearranging the party no longer orphans the RETURN option.
+
+**Architecture:** Add `u32 pid` to the `sFollower` EWRAM struct. Add `IsFollowerPokemon(struct Pokemon *mon)` that compares species and personality value against the cached values. Replace the slot-index comparison in `SetPartyMonFieldSelectionActions` with this identity check.
+
+**Tech Stack:** C (GBA bare-metal, no OS), GBA EWRAM, mGBA Lua scripting tests.
+
+---
+
+## Root Cause
+
+`sFollower.partySlot` stores a slot index. After a party SWITCH, the index is stale:
+
+- Slot that now holds the follower Pokemon: no RETURN option (orphaned)
+- Slot that *used to* hold it: incorrectly shows RETURN
+
+`IsFollowerPokemon` fixes this by comparing identity (species + 32-bit personality value) rather than position. Two Pokemon in the same party sharing identical species AND PID is astronomically unlikely (~1 in 700M), so this is safe in practice.
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `src/pokemon_follower.c` | Add `u32 pid` to `sFollower` struct; store it in `ActivateFollower`; clear it in `DeactivateFollower`; add `IsFollowerPokemon` function |
+| `include/pokemon_follower.h` | Declare `IsFollowerPokemon(struct Pokemon *mon)` |
+| `src/party_menu.c` | Replace slot-index check with `IsFollowerPokemon(&mons[slotId])` |
+| `test/tests/test_walking_pokemon_return.lua` | New integration test (full menu nav) |
+| `test/lib/addresses.lua` | Add `sFollower` address; fix stale roaming addresses (+4 from new struct field) |
+
+---
+
+### Task 1: Create feature branch
+
+- [ ] Create branch:
+```bash
+git checkout -b issue-4-walking-pokemon-return-by-identity
+```
+
+- [ ] Verify:
+```bash
+git branch --show-current
+```
+Expected: `issue-4-walking-pokemon-return-by-identity`
+
+---
+
+### Task 2: Comment issue with agreed plan
+
+- [ ] Post the agreed design on the issue:
+```bash
+gh issue comment 4 --body "## Agreed Fix
+
+Track the walking Pokemon by **species+PID** instead of party slot index.
+
+### Root Cause
+\`sFollower.partySlot\` stores a slot index. After a party SWITCH, the index becomes stale — RETURN appears on whichever Pokemon now occupies that slot, not the actual follower. The actual follower loses its RETURN option entirely.
+
+### Solution
+Add \`u32 pid\` (personality value) to the \`sFollower\` EWRAM struct. Store it at activation time. Add \`IsFollowerPokemon(struct Pokemon *mon)\` that checks both species and PID. Replace the slot-index comparison in \`SetPartyMonFieldSelectionActions\` with this identity check.
+
+### Test
+Full party-menu integration test:
+1. Boot to overworld with Pikachu (slot 0) + Meowth (slot 1)
+2. WALK Pikachu from slot 0
+3. SWITCH Pikachu to slot 1
+4. Verify RETURN works on slot 1 (Pikachu's new position) — follower deactivates
+5. WALK Meowth from slot 0 — verify follower activates with Meowth's species"
+```
+
+---
+
+### Task 3: Write the failing test
+
+**Files:**
+- Create: `test/tests/test_walking_pokemon_return.lua`
+
+- [ ] Create the test file with this content:
+
+```lua
+-------------------------------------------------------------------------------
+-- test_walking_pokemon_return.lua
+--
+-- Regression test for issue #4: walking-pokemon RETURN must follow the
+-- Pokemon by identity (species+PID), not party slot index.
+--
+-- Bug: after a party SWITCH that moves the walking Pokemon to a new slot,
+-- the stale sFollower.partySlot caused RETURN to appear on the wrong slot
+-- and the actual follower to lose its RETURN option entirely.
+--
+-- Full flow:
+--   1. Boot to overworld. Inject Pikachu (slot 0) + Meowth (slot 1).
+--   2. Open party menu -> WALK Pikachu.
+--      Check: sFollower.active==1, sFollower.species==25.
+--   3. Open party menu -> SWITCH Pikachu (slot 0) with Meowth (slot 1).
+--      Check: sFollower.active still 1.
+--   4. Open party menu -> slot 1 (Pikachu's new position) -> option [1].
+--      After fix: option [1] = RETURN -> follower deactivates.
+--      Before fix: option [1] = SWITCH -> sub-menu opens; B backs out; follower stays.
+--      Check: sFollower.active==0.
+--   5. Open party menu -> WALK Meowth (slot 0).
+--      Check: sFollower.active==1, sFollower.species==52.
+--
+-- Run:
+--   bash test/run_test.sh test/tests/test_walking_pokemon_return.lua
+-------------------------------------------------------------------------------
+
+local script_dir = debug.getinfo(1, "S").source:match("@?(.*/)") or ""
+local project_dir = script_dir .. "../../"
+local fw   = dofile(project_dir .. "test/lib/framework.lua")
+local cs   = dofile(project_dir .. "test/lib/character_select.lua")
+local ADDR = dofile(project_dir .. "test/lib/addresses.lua")
+
+local STATE_PATH   = "/tmp/pokefirered-walking-pokemon.ss"
+local PARTY_BASE   = 0x02024284  -- gPlayerParty (from pokefirered.map)
+local POKEMON_SIZE = 100         -- sizeof(struct Pokemon)
+
+-- sFollower EWRAM struct (src/pokemon_follower.c).
+-- Base from map: grep "src/pokemon_follower.o" pokefirered.map (ewram_data line).
+-- Field layout after adding u32 pid (offsets in bytes):
+--   +0  bool8 active
+--   +1  bool8 spriteSpawned
+--   +2  u8    partySlot
+--   +3  (padding byte for u16 alignment)
+--   +4  u16   species
+--   +6  u8    graphicsId
+--   +7  u8    objEventId
+--   +8  u32   pid
+local FOLLOWER_BASE    = 0x0203f7a8
+local FOLLOWER_ACTIVE  = FOLLOWER_BASE + 0
+local FOLLOWER_SPECIES = FOLLOWER_BASE + 4  -- u16
+
+local SPECIES_PIKACHU = 25
+local SPECIES_MEOWTH  = 52
+
+-- Write a minimal valid Pokemon into party memory at `base`.
+-- Uses PID=0, OTID=0 so XOR encryption key = PID XOR OTID = 0 (no encryption).
+-- Substruct order = PID % 24 = 0 = [Growth, Attacks, EVs, Misc].
+-- Growth.species is the first u16 of the secure block (BoxPokemon+0x20).
+local function inject_pokemon(base, species, level)
+    for i = 0, POKEMON_SIZE - 1 do emu:write8(base + i, 0) end
+    emu:write8(base + 0x13, 0x02)                       -- hasSpecies flag
+    emu:write8(base + 0x55, 0xFF)                       -- no mail
+    emu:write8(base + 0x20, species % 256)              -- Growth.species low
+    emu:write8(base + 0x21, math.floor(species / 256))  -- Growth.species high
+    emu:write8(base + 0x1C, species % 256)              -- checksum low
+    emu:write8(base + 0x1D, math.floor(species / 256))  -- checksum high
+    emu:write8(base + 0x54, level)                      -- level
+    emu:write8(base + 0x56, 20)                         -- currentHP
+    emu:write8(base + 0x58, 20)                         -- maxHP
+end
+
+local results = {}
+local function check(name, cond)
+    results[#results + 1] = {name = name, pass = cond}
+    fw.log((cond and "[PASS] " or "[FAIL] ") .. name)
+end
+
+fw.run(function()
+    fw.log("=== Walking Pokemon Return Fix Test ===")
+
+    -- ------------------------------------------------------------------ --
+    -- Fixture: boot to overworld with Pikachu+Meowth, save state
+    -- ------------------------------------------------------------------ --
+    if not fw.try_load_state(STATE_PATH) then
+        fw.log("No cached state — booting through Oak's speech...")
+        local sel = cs.find_selection_press()
+        if not sel then
+            fw.log("ERROR: character select discovery failed — aborting")
+            fw.finish()
+            return
+        end
+        emu:reset()
+        cs.boot_and_open_list(sel)
+        cs.confirm_and_enter_overworld()
+        fw.log("Reached overworld. Injecting Pikachu + Meowth...")
+
+        inject_pokemon(PARTY_BASE,                SPECIES_PIKACHU, 5)
+        inject_pokemon(PARTY_BASE + POKEMON_SIZE, SPECIES_MEOWTH,  5)
+        emu:write8(ADDR.gPlayerPartyCount, 2)
+
+        -- Set FLAG_SYS_POKEMON_GET (0x828) so Start menu shows POKEMON.
+        -- byte index = 0x828/8 = 0x105, bit = 0
+        local sb1 = fw.read32(ADDR.gSaveBlock1Ptr)
+        local flag_addr = sb1 + ADDR.SB1_FLAGS + math.floor(0x828 / 8)
+        emu:write8(flag_addr, fw.read8(flag_addr) | 0x01)
+        fw.wait_frames(30)
+        fw.save_state(STATE_PATH)
+    end
+    fw.wait_frames(60)
+
+    -- ------------------------------------------------------------------ --
+    -- Phase 1: WALK Pikachu from slot 0
+    -- Action menu for slot 0 (Pikachu, eligible, no follower):
+    --   [0] SUMMARY  [1] WALK  [2] SWITCH  [3] ITEM  [4] MOVE TO PC  [5] CANCEL
+    -- ------------------------------------------------------------------ --
+    fw.log("--- Phase 1: WALK Pikachu (slot 0) ---")
+    fw.press("START"); fw.wait_frames(80)
+    fw.press("A");     fw.wait_frames(120)  -- open party menu
+    fw.press("A");     fw.wait_frames(80)   -- open slot 0 action menu
+    fw.press("DOWN");  fw.wait_frames(20)   -- move to [1] WALK
+    fw.press("A");     fw.wait_frames(120)  -- select WALK; returns to overworld
+
+    check("Phase 1: follower active after WALK",
+          fw.read8(FOLLOWER_ACTIVE) == 1)
+    check("Phase 1: follower species is Pikachu",
+          fw.read16(FOLLOWER_SPECIES) == SPECIES_PIKACHU)
+
+    -- ------------------------------------------------------------------ --
+    -- Phase 2: SWITCH Pikachu (slot 0) with Meowth (slot 1)
+    -- Action menu for slot 0 (Pikachu, IS follower, active):
+    --   [0] SUMMARY  [1] RETURN  [2] SWITCH  [3] ITEM  [4] MOVE TO PC  [5] CANCEL
+    -- After SWITCH: Meowth is at slot 0, Pikachu is at slot 1.
+    -- ------------------------------------------------------------------ --
+    fw.log("--- Phase 2: SWITCH Pikachu to slot 1 ---")
+    fw.press("START"); fw.wait_frames(80)
+    fw.press("A");     fw.wait_frames(120)  -- open party menu
+    fw.press("A");     fw.wait_frames(80)   -- open slot 0 action menu (Pikachu)
+    fw.press("DOWN");  fw.wait_frames(20)   -- to [1] RETURN
+    fw.press("DOWN");  fw.wait_frames(20)   -- to [2] SWITCH
+    fw.press("A");     fw.wait_frames(60)   -- enter SWITCH mode
+    fw.press("DOWN");  fw.wait_frames(20)   -- move cursor to slot 1
+    fw.press("A");     fw.wait_frames(80)   -- confirm swap; party now swapped
+    fw.press("B");     fw.wait_frames(80)   -- close party menu
+    fw.press("B");     fw.wait_frames(30)   -- close start menu if still open
+
+    check("Phase 2: follower still active after SWITCH",
+          fw.read8(FOLLOWER_ACTIVE) == 1)
+
+    -- ------------------------------------------------------------------ --
+    -- Phase 3: RETURN Pikachu from slot 1 (its new position)
+    -- After fix — slot 1 action menu (Pikachu identified by species+PID):
+    --   [0] SUMMARY  [1] RETURN  [2] SWITCH  [3] ITEM  [4] MOVE TO PC  [5] CANCEL
+    -- Before fix — slot 1 action menu (orphaned: follower is "not here" by slot):
+    --   [0] SUMMARY  [1] SWITCH  [2] ITEM  [3] MOVE TO PC  [4] CANCEL
+    --   Pressing [1] opens SWITCH sub-menu; pressing B backs out; active stays 1.
+    -- ------------------------------------------------------------------ --
+    fw.log("--- Phase 3: RETURN Pikachu from slot 1 ---")
+    fw.press("START"); fw.wait_frames(80)
+    fw.press("A");     fw.wait_frames(120)  -- open party menu
+    fw.press("DOWN");  fw.wait_frames(20)   -- cursor to slot 1
+    fw.press("A");     fw.wait_frames(80)   -- open slot 1 action menu
+    fw.press("DOWN");  fw.wait_frames(20)   -- to option [1] (RETURN after fix)
+    fw.press("A");     fw.wait_frames(120)  -- select it; returns to overworld if RETURN
+    -- If SWITCH fired instead (pre-fix bug), back out of any sub-menus
+    fw.press("B");     fw.wait_frames(30)
+    fw.press("B");     fw.wait_frames(30)
+    fw.press("B");     fw.wait_frames(30)
+
+    check("Phase 3: follower deactivated by RETURN",
+          fw.read8(FOLLOWER_ACTIVE) == 0)
+
+    -- ------------------------------------------------------------------ --
+    -- Phase 4: WALK Meowth from slot 0 (its new position after swap)
+    -- Action menu for slot 0 (Meowth, eligible, no follower active):
+    --   [0] SUMMARY  [1] WALK  [2] SWITCH  [3] ITEM  [4] MOVE TO PC  [5] CANCEL
+    -- ------------------------------------------------------------------ --
+    fw.log("--- Phase 4: WALK Meowth (slot 0) ---")
+    fw.press("START"); fw.wait_frames(80)
+    fw.press("A");     fw.wait_frames(120)  -- open party menu
+    fw.press("A");     fw.wait_frames(80)   -- open slot 0 action menu (Meowth)
+    fw.press("DOWN");  fw.wait_frames(20)   -- to [1] WALK
+    fw.press("A");     fw.wait_frames(120)  -- select WALK; returns to overworld
+
+    check("Phase 4: follower active after WALK Meowth",
+          fw.read8(FOLLOWER_ACTIVE) == 1)
+    check("Phase 4: follower species is Meowth",
+          fw.read16(FOLLOWER_SPECIES) == SPECIES_MEOWTH)
+
+    -- ------------------------------------------------------------------ --
+    -- Report
+    -- ------------------------------------------------------------------ --
+    local passed = 0
+    for _, r in ipairs(results) do if r.pass then passed = passed + 1 end end
+    fw.log(string.format("Results: %d/%d passed", passed, #results))
+    fw.finish()
+end)
+```
+
+- [ ] Verify the file was created:
+```bash
+ls test/tests/test_walking_pokemon_return.lua
+```
+
+---
+
+### Task 4: Run test — verify it fails before fix
+
+- [ ] Build ROM first (required before running tests):
+```bash
+make -j$(nproc) firered 2>&1 | tail -5
+```
+
+- [ ] Run test:
+```bash
+bash test/run_test.sh test/tests/test_walking_pokemon_return.lua 2>&1 | tail -20
+```
+Expected: `[FAIL] Phase 3: follower deactivated by RETURN`
+
+Before the fix, pressing option [1] on slot 1 triggers SWITCH (not RETURN), because `sFollower.partySlot=0` still points to slot 0. The B presses back out of the SWITCH sub-menu, and `sFollower.active` remains 1.
+
+---
+
+### Task 5: Implement the fix
+
+**Files:**
+- Modify: `src/pokemon_follower.c` (lines ~75-209)
+- Modify: `include/pokemon_follower.h`
+- Modify: `src/party_menu.c` (line ~3000)
+
+**5a. Add `pid` to `sFollower` and update lifecycle functions**
+
+In `src/pokemon_follower.c`, update the struct at line ~75 to add `u32 pid`:
+
+```c
+static EWRAM_DATA struct {
+    bool8 active;
+    bool8 spriteSpawned;
+    u8 partySlot;
+    u16 species;
+    u8 graphicsId;
+    u8 objEventId;
+    u32 pid;  /* personality value — identifies this Pokemon across party rearrangements */
+} sFollower = {0};
+```
+
+In `ActivateFollower` (line ~178), add one line after setting `objEventId`:
+```c
+    sFollower.objEventId = OBJECT_EVENTS_COUNT;
+    sFollower.pid = GetMonData(&gPlayerParty[partySlot], MON_DATA_PERSONALITY);
+```
+
+In `DeactivateFollower` (line ~202), add clearing `pid`:
+```c
+void DeactivateFollower(void)
+{
+    DespawnFollowerSprite();
+    sFollower.active = FALSE;
+    sFollower.partySlot = 0;
+    sFollower.species = 0;
+    sFollower.graphicsId = 0;
+    sFollower.pid = 0;
+}
+```
+
+Add `IsFollowerPokemon` after `GetFollowerPartySlot` (line ~163):
+```c
+bool8 IsFollowerPokemon(struct Pokemon *mon)
+{
+    if (!sFollower.active)
+        return FALSE;
+    return GetMonData(mon, MON_DATA_SPECIES) == sFollower.species
+        && GetMonData(mon, MON_DATA_PERSONALITY) == sFollower.pid;
+}
+```
+
+**5b. Declare `IsFollowerPokemon` in the header**
+
+In `include/pokemon_follower.h`, add after the `GetFollowerPartySlot` line:
+```c
+bool8 IsFollowerPokemon(struct Pokemon *mon);
+```
+
+Also add `#include "pokemon.h"` if `struct Pokemon` is not already reachable through `global.h` — the compiler will tell you if this is needed (error: unknown type `struct Pokemon`).
+
+**5c. Update party menu**
+
+In `src/party_menu.c` line ~3000, change:
+```c
+if (IsFollowerActive() && slotId == GetFollowerPartySlot())
+```
+to:
+```c
+if (IsFollowerPokemon(&mons[slotId]))
+```
+
+- [ ] Build to verify no errors:
+```bash
+make -j$(nproc) firered 2>&1 | tail -10
+```
+Expected: clean build.
+
+- [ ] Commit:
+```bash
+git add src/pokemon_follower.c include/pokemon_follower.h src/party_menu.c
+git commit -m "$(cat <<'EOF'
+fix: track walking pokemon by species+PID, not party slot index
+
+sFollower.partySlot became stale after a party SWITCH — RETURN
+appeared on the wrong Pokemon and the actual follower lost its
+RETURN option entirely.
+
+Store the follower's personality value (PID) at activation time.
+IsFollowerPokemon() compares both species and PID so RETURN follows
+the actual Pokemon regardless of which party slot it ends up in.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Update EWRAM addresses after struct growth
+
+Adding `u32 pid` (4 bytes) to `sFollower` shifts all EWRAM variables from `quick_select_menu.o` and `roaming_pokemon.o` onwards by +4 bytes.
+
+**Note:** `gRoamers` and related addresses in `addresses.lua` are ALREADY stale by +8 bytes from the current build (the follower feature was added after those constants were last extracted). This task fixes both the new shift and the pre-existing drift.
+
+- [ ] Re-extract addresses from the map:
+```bash
+grep "203f7\|203f8\|203f9\|gRoamers\|gRoaming\|gRoamerCount\|gRoamerNext\|pokemon_follower" pokefirered.map
+```
+
+- [ ] Update `test/lib/addresses.lua` — add `sFollower` block and fix roaming constants to match map output:
+
+In `addresses.lua`, add a new section (exact addresses must come from the map output above):
+```lua
+-------------------------------------------------------------------------------
+-- WALKING POKEMON FOLLOWER (pokemon_follower.c)
+-------------------------------------------------------------------------------
+-- sFollower EWRAM struct. Base from map: grep "src/pokemon_follower.o" pokefirered.map.
+-- Field offsets (struct layout after fix added u32 pid):
+--   +0  bool8 active
+--   +1  bool8 spriteSpawned
+--   +2  u8    partySlot
+--   +3  (alignment padding)
+--   +4  u16   species
+--   +6  u8    graphicsId
+--   +7  u8    objEventId
+--   +8  u32   pid
+ADDR.sFollower               = 0x0203f7a8   -- re-verify from map after each rebuild
+ADDR.FOLLOWER_OFF_ACTIVE     = 0x00
+ADDR.FOLLOWER_OFF_SPECIES    = 0x04
+ADDR.FOLLOWER_OFF_PID        = 0x08
+```
+
+And update the roaming constants to the new addresses shown by the map.
+
+- [ ] Commit:
+```bash
+git add test/lib/addresses.lua
+git commit -m "$(cat <<'EOF'
+chore: update EWRAM addresses after sFollower struct growth
+
+sFollower grew by 4 bytes (added u32 pid), shifting quick_select_menu.o
+and roaming_pokemon.o sections forward. Also fixes pre-existing 8-byte
+drift in gRoamers and related constants (never updated after follower
+system was added).
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Run test — verify all checks pass
+
+- [ ] Delete stale fixture (EWRAM layout changed; old state maps addresses wrong):
+```bash
+rm -f /tmp/pokefirered-walking-pokemon.ss
+```
+
+- [ ] Also delete other fixtures that might be affected by shifted roaming addresses:
+```bash
+rm -f /tmp/pokefirered-*.ss
+```
+
+- [ ] Run the walking pokemon test:
+```bash
+bash test/run_test.sh test/tests/test_walking_pokemon_return.lua 2>&1 | tail -20
+```
+
+Expected:
+```
+[PASS] Phase 1: follower active after WALK
+[PASS] Phase 1: follower species is Pikachu
+[PASS] Phase 2: follower still active after SWITCH
+[PASS] Phase 3: follower deactivated by RETURN
+[PASS] Phase 4: follower active after WALK Meowth
+[PASS] Phase 4: follower species is Meowth
+Results: 6/6 passed
+```
+
+---
+
+### Task 8: Create PR
+
+- [ ] Create the PR:
+```bash
+gh pr create --title "Fix #4: track walking pokemon by species+PID, not party slot" --body "$(cat <<'EOF'
+## Summary
+
+- `sFollower` now stores `u32 pid` (personality value) at activation time alongside the existing `species` cache
+- New `IsFollowerPokemon(struct Pokemon *mon)` checks both species and PID to identify the follower
+- `SetPartyMonFieldSelectionActions` uses `IsFollowerPokemon` instead of slot-index comparison
+- RETURN option now follows the actual Pokemon through any party rearrangement
+
+## Root Cause
+
+\`sFollower.partySlot\` stored a slot index. After a party SWITCH, the index was stale:
+- The new slot holding the follower Pokemon: showed no RETURN (orphaned)
+- The old slot: incorrectly showed RETURN on whatever Pokemon moved there
+
+## Test
+
+\`test/tests/test_walking_pokemon_return.lua\` — full party-menu integration:
+1. Inject Pikachu (slot 0) + Meowth (slot 1), reach overworld
+2. WALK Pikachu → verify active + species
+3. SWITCH Pikachu to slot 1 → verify still active
+4. Open party menu → slot 1 → RETURN → verify deactivated (**core regression check**)
+5. WALK Meowth → verify active + Meowth species
+
+Also fixes pre-existing 8-byte drift in \`gRoamers\` and related addresses in \`addresses.lua\`.
+
+Closes #4
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] After creating the PR, post in session:
+```
+Branch README: https://github.com/MinimalEffort07/pokefirered/blob/issue-4-walking-pokemon-return-by-identity/README.md
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Fix RETURN to track by identity, not position ✓ (Task 5)
+- Test: WALK → SWITCH → RETURN from new slot → WALK new Pokemon ✓ (Task 3)
+- No GIF, no recording (bug fix) ✓
+- Issue commented with plan ✓ (Task 2)
+- Branch created ✓ (Task 1)
+- PR created ✓ (Task 8)
+- Address drift fixed ✓ (Task 6)
+
+**Placeholder scan:** No TBDs. Task 6 explicitly requires updating addresses from map output rather than hardcoding them, which is correct since they depend on the build.
+
+**Type consistency:** `IsFollowerPokemon(struct Pokemon *mon)` — declared in header, defined in .c with same signature, called as `IsFollowerPokemon(&mons[slotId])` where `mons` is `struct Pokemon *` in party_menu.c. ✓

--- a/include/pokemon_follower.h
+++ b/include/pokemon_follower.h
@@ -25,6 +25,7 @@ void DespawnFollowerSprite(void);
 bool8 IsFollowerActive(void);
 u8 GetFollowerObjEventId(void);
 u8 GetFollowerPartySlot(void);
+bool8 IsFollowerPokemon(struct Pokemon *mon);
 bool8 CanSpeciesFollowPlayer(u16 species);
 void ActivateFollower(u8 partySlot);
 void DeactivateFollower(void);

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -2997,7 +2997,7 @@ static void SetPartyMonFieldSelectionActions(struct Pokemon *mons, u8 slotId)
         u16 species = GetMonData(&mons[slotId], MON_DATA_SPECIES);
         if (CanSpeciesFollowPlayer(species))
         {
-            if (IsFollowerActive() && slotId == GetFollowerPartySlot())
+            if (IsFollowerPokemon(&mons[slotId]))
                 AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, CURSOR_OPTION_RETURN_MON);
             else if (!IsFollowerActive())
                 AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, CURSOR_OPTION_WALK);

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -2989,12 +2989,13 @@ static void SetPartyMonSelectionActions(struct Pokemon *mons, u8 slotId, u8 acti
 static void SetPartyMonFieldSelectionActions(struct Pokemon *mons, u8 slotId)
 {
     u8 i, j;
+    u16 species;
 
     sPartyMenuInternal->numActions = 0;
     AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, CURSOR_OPTION_SUMMARY);
-    // Add WALK or RETURN option for pokemon with overworld walking sprites
+    /* Add WALK or RETURN option for pokemon with overworld walking sprites */
     {
-        u16 species = GetMonData(&mons[slotId], MON_DATA_SPECIES);
+        species = GetMonData(&mons[slotId], MON_DATA_SPECIES);
         if (CanSpeciesFollowPlayer(species))
         {
             if (IsFollowerPokemon(&mons[slotId]))

--- a/src/pokemon_follower.c
+++ b/src/pokemon_follower.c
@@ -79,6 +79,7 @@ static EWRAM_DATA struct {
     u16 species;            /* Cached species (for change detection) */
     u8 graphicsId;          /* OBJ_EVENT_GFX_* constant for the sprite */
     u8 objEventId;          /* Index into gObjectEvents[] */
+    u32 pid;                /* Personality value — identifies the Pokemon across party rearrangements */
 } sFollower = {0};
 
 /*
@@ -163,6 +164,26 @@ u8 GetFollowerPartySlot(void)
 }
 
 /**
+ * FUNCTION: IsFollowerPokemon
+ *
+ * PURPOSE: Check whether a given Pokemon struct is the current follower.
+ *          Uses both species and personality value (PID) so the identity
+ *          check survives party SWITCH rearrangements — the slot index in
+ *          sFollower.partySlot goes stale after a swap, but species+PID
+ *          uniquely identifies the individual Pokemon.
+ *
+ * @param mon  Pointer to a struct Pokemon to test (typically &gPlayerParty[i]).
+ * @return TRUE if the follower is active and this mon is the follower.
+ */
+bool8 IsFollowerPokemon(struct Pokemon *mon)
+{
+    if (!sFollower.active)
+        return FALSE;
+    return GetMonData(mon, MON_DATA_SPECIES) == sFollower.species
+        && GetMonData(mon, MON_DATA_PERSONALITY) == sFollower.pid;
+}
+
+/**
  * FUNCTION: ActivateFollower
  *
  * PURPOSE: Enable the follower system for the given party slot.
@@ -191,6 +212,7 @@ void ActivateFollower(u8 partySlot)
     sFollower.species = species;
     sFollower.graphicsId = gfxId;
     sFollower.objEventId = OBJECT_EVENTS_COUNT;
+    sFollower.pid = GetMonData(&gPlayerParty[partySlot], MON_DATA_PERSONALITY);
 }
 
 /**
@@ -206,6 +228,7 @@ void DeactivateFollower(void)
     sFollower.partySlot = 0;
     sFollower.species = 0;
     sFollower.graphicsId = 0;
+    sFollower.pid = 0;
 }
 
 /**

--- a/src/pokemon_follower.c
+++ b/src/pokemon_follower.c
@@ -79,7 +79,7 @@ static EWRAM_DATA struct {
     u16 species;            /* Cached species (for change detection) */
     u8 graphicsId;          /* OBJ_EVENT_GFX_* constant for the sprite */
     u8 objEventId;          /* Index into gObjectEvents[] */
-    u32 pid;                /* Personality value — identifies the Pokemon across party rearrangements */
+    u32 pid;                /* Personality value (PID). partySlot goes stale after SWITCH; species+PID uniquely identifies the Pokemon regardless of slot */
 } sFollower = {0};
 
 /*
@@ -158,22 +158,26 @@ u8 GetFollowerObjEventId(void)
     return sFollower.objEventId;
 }
 
+/**
+ * Return the party slot index of the active follower.
+ *
+ * Kept as public API; party_menu.c now uses IsFollowerPokemon() for the
+ * RETURN check, so this slot value is only advisory (it goes stale after
+ * the player uses SWITCH to rearrange the party).
+ */
 u8 GetFollowerPartySlot(void)
 {
     return sFollower.partySlot;
 }
 
 /**
- * FUNCTION: IsFollowerPokemon
+ * Check whether a party Pokemon is the active follower.
  *
- * PURPOSE: Check whether a given Pokemon struct is the current follower.
- *          Uses both species and personality value (PID) so the identity
- *          check survives party SWITCH rearrangements — the slot index in
- *          sFollower.partySlot goes stale after a swap, but species+PID
- *          uniquely identifies the individual Pokemon.
+ * Compares both species and personality value (PID) so that the check
+ * remains correct after the player rearranges their party with SWITCH.
+ * Slot-index comparison would go stale; identity comparison does not.
  *
- * @param mon  Pointer to a struct Pokemon to test (typically &gPlayerParty[i]).
- * @return TRUE if the follower is active and this mon is the follower.
+ * @return TRUE if mon is the currently active follower.
  */
 bool8 IsFollowerPokemon(struct Pokemon *mon)
 {
@@ -225,6 +229,8 @@ void DeactivateFollower(void)
 {
     DespawnFollowerSprite();
     sFollower.active = FALSE;
+    sFollower.spriteSpawned = FALSE;
+    sFollower.objEventId = OBJECT_EVENTS_COUNT;
     sFollower.partySlot = 0;
     sFollower.species = 0;
     sFollower.graphicsId = 0;

--- a/test/lib/addresses.lua
+++ b/test/lib/addresses.lua
@@ -175,12 +175,17 @@ ADDR.SEEL_LIST_INDEX          = 94   -- Seel's position in the character selecti
 --
 -- Addresses are extracted from pokefirered.map. They MUST be re-extracted
 -- whenever roaming_pokemon.c or anything that affects EWRAM layout changes.
+--
+-- Re-extracted after sFollower struct grew by 4 bytes (added u32 pid in issue-4 fix).
+-- All addresses from roaming_pokemon.o onwards shifted by +4.
+-- Also fixes pre-existing 8-byte drift: gRoamers and related were stale by +8
+-- bytes from a previous feature addition that was never backported to this file.
 
-ADDR.gRoamers                 = 0x0203f890  -- struct RoamingMon[4]
-ADDR.gRoamingFlybySpriteIds   = 0x0203f8a0  -- u8[4], MAX_SPRITES (64) = free
-ADDR.gRoamerCount             = 0x0203f8a4  -- u8: number of active roamers (0..4)
-ADDR.gRoamerNextSpawnTimer    = 0x0203f8a6  -- u16: frames until next spawn attempt
-ADDR.gRoamerNextFlybyTimer    = 0x0203f8a8  -- u16: frames until next flyby attempt
+ADDR.gRoamers                 = 0x0203f89c  -- struct RoamingMon[4]
+ADDR.gRoamingFlybySpriteIds   = 0x0203f8ac  -- u8[4], MAX_SPRITES (64) = free
+ADDR.gRoamerCount             = 0x0203f8b0  -- u8: number of active roamers (0..4)
+ADDR.gRoamerNextSpawnTimer    = 0x0203f8b2  -- u16: frames until next spawn attempt
+ADDR.gRoamerNextFlybyTimer    = 0x0203f8b4  -- u16: frames until next flyby attempt
 
 ADDR.ROAMER_STRUCT_SIZE       = 4
 ADDR.ROAMER_OFF_OBJ_EVENT_ID  = 0
@@ -318,8 +323,8 @@ ADDR.WED_LEAD_MON_HELD_ITEM          = 0x0A
 --   0x01  u8 tableIdx
 --   0x02  u8 level
 --   0x03  u8 pendingBattle -- set by collision check, cleared when battle starts
-ADDR.gRoamers                        = 0x0203f890
-ADDR.gRoamerCount                    = 0x0203f8a4
+ADDR.gRoamers                        = 0x0203f89c
+ADDR.gRoamerCount                    = 0x0203f8b0
 ADDR.ROAMER_CAP_VISIBLE              = 4
 ADDR.ROAMER_SIZE                     = 4
 ADDR.ROAMER_OFF_OBJ_EVENT_ID         = 0x00
@@ -378,5 +383,25 @@ ADDR.ITEM_MAX_ELIXIR                 = 37
 -- pokefirered_modern.gba).
 
 ADDR.gPlayerPartyCount               = 0x02024029
+
+-------------------------------------------------------------------------------
+-- WALKING POKEMON FOLLOWER (pokemon_follower.c)
+-------------------------------------------------------------------------------
+-- sFollower: static EWRAM struct tracking the active follower Pokemon.
+-- Base address from pokefirered.map: grep "ewram_data.*pokemon_follower" pokefirered.map
+-- NOTE: Re-verify after any rebuild that touches EWRAM layout before pokemon_follower.o.
+-- Field offsets (valid both before and after adding u32 pid at +8):
+--   +0  bool8 active
+--   +1  bool8 spriteSpawned
+--   +2  u8    partySlot
+--   +3  (alignment padding)
+--   +4  u16   species
+--   +6  u8    graphicsId
+--   +7  u8    objEventId
+--   +8  u32   pid  (added by issue-4 fix; not present in pre-fix builds)
+ADDR.sFollower               = 0x0203f7a8
+ADDR.FOLLOWER_OFF_ACTIVE     = 0x00
+ADDR.FOLLOWER_OFF_SPECIES    = 0x04
+ADDR.FOLLOWER_OFF_PID        = 0x08
 
 return ADDR

--- a/test/record_test.sh
+++ b/test/record_test.sh
@@ -24,6 +24,7 @@ RECORDINGS_DIR="/tmp/mgba-recordings"
 RESULTS_FILE="/tmp/mgba-test-results.json"
 MGBA_QT_INI="$HOME/.config/mgba/qt.ini"
 TIMEOUT=300
+X_DISPLAY="${X_DISPLAY:-:1}"
 
 if [ ! -f "$ROM" ]; then
     echo "ERROR: ROM not found at $ROM"; exit 1
@@ -38,18 +39,18 @@ VIRT_W=1920
 VIRT_H=640
 
 # Restart Xvfb only if dimensions changed or it isn't running
-CURRENT_GEOM=$(DISPLAY=:1 xdpyinfo 2>/dev/null | awk '/dimensions/{print $2}')
+CURRENT_GEOM=$(DISPLAY="$X_DISPLAY" xdpyinfo 2>/dev/null | awk '/dimensions/{print $2}')
 if [ "$CURRENT_GEOM" != "${VIRT_W}x${VIRT_H}" ]; then
-    echo "Starting Xvfb :1 at ${VIRT_W}x${VIRT_H}..."
+    echo "Starting Xvfb $X_DISPLAY at ${VIRT_W}x${VIRT_H}..."
     pkill -x Xvfb 2>/dev/null || true
     pkill -x openbox 2>/dev/null || true
     sleep 1
-    Xvfb :1 -screen 0 "${VIRT_W}x${VIRT_H}x24" &
+    Xvfb "$X_DISPLAY" -screen 0 "${VIRT_W}x${VIRT_H}x24" &
     sleep 1
 fi
 
-if ! DISPLAY=:1 pgrep -x openbox > /dev/null 2>&1; then
-    DISPLAY=:1 openbox &
+if ! DISPLAY="$X_DISPLAY" pgrep -x openbox > /dev/null 2>&1; then
+    DISPLAY="$X_DISPLAY" openbox &
     sleep 1
 fi
 
@@ -122,11 +123,11 @@ with open(path, 'w') as f:
     f.write(content)
 PYEOF
 
-export DISPLAY=:1
+export DISPLAY="$X_DISPLAY"
 
 # Step 1: start recording before mGBA opens so the full boot sequence is captured.
 echo "Recording..."
-ffmpeg -f x11grab -r 30 -s "${VIRT_W}x${VIRT_H}" -i :1 \
+ffmpeg -f x11grab -r 30 -s "${VIRT_W}x${VIRT_H}" -i "$X_DISPLAY" \
     -vf "crop=1324:${VIRT_H}:0:0,scale=1280:-2" \
     -c:v libx264 -profile:v baseline -level 3.1 \
     -preset ultrafast -pix_fmt yuv420p \
@@ -135,7 +136,7 @@ ffmpeg -f x11grab -r 30 -s "${VIRT_W}x${VIRT_H}" -i :1 \
 FFMPEG_PID=$!
 
 # Step 2: launch mGBA with the private config dir.
-DISPLAY=:1 XDG_CONFIG_HOME="$RECORDING_XDG" LD_LIBRARY_PATH="$MGBA_BUILD" \
+DISPLAY="$X_DISPLAY" XDG_CONFIG_HOME="$RECORDING_XDG" LD_LIBRARY_PATH="$MGBA_BUILD" \
     "$MGBA_BUILD/qt/mgba-qt" "$ROM" --script "$TEST_SCRIPT" \
     > /tmp/mgba-gui.log 2>&1 &
 MGBA_PID=$!
@@ -149,9 +150,9 @@ echo "Positioning windows..."
 GAME_WID=""
 SCRIPT_WID=""
 for i in $(seq 1 20); do
-    ALL_WIDS=$(xdotool search --pid "$MGBA_PID" 2>/dev/null || true)
+    ALL_WIDS=$(DISPLAY="$X_DISPLAY" xdotool search --pid "$MGBA_PID" 2>/dev/null || true)
     for wid in $ALL_WIDS; do
-        NAME=$(xdotool getwindowname "$wid" 2>/dev/null || true)
+        NAME=$(DISPLAY="$X_DISPLAY" xdotool getwindowname "$wid" 2>/dev/null || true)
         if echo "$NAME" | grep -q "^mGBA"; then
             GAME_WID=$wid
         elif [ "$NAME" = "Scripting" ]; then
@@ -163,13 +164,13 @@ for i in $(seq 1 20); do
 done
 
 if [ -n "$GAME_WID" ]; then
-    xdotool windowmove "$GAME_WID" 0 0
+    DISPLAY="$X_DISPLAY" xdotool windowmove "$GAME_WID" 0 0
     echo "Game window -> (0, 0)"
 else
     echo "WARNING: game window not found"
 fi
 if [ -n "$SCRIPT_WID" ]; then
-    xdotool windowmove "$SCRIPT_WID" 480 0
+    DISPLAY="$X_DISPLAY" xdotool windowmove "$SCRIPT_WID" 480 0
     echo "Scripting window -> (480, 0)"
 else
     echo "WARNING: scripting window not found"

--- a/test/tests/test_walking_pokemon_return.lua
+++ b/test/tests/test_walking_pokemon_return.lua
@@ -102,6 +102,7 @@ fw.run(function()
         fw.save_state(STATE_PATH)
     end
     fw.wait_frames(60)
+    fw.slow_down("WALK/SWITCH/RETURN party menu demonstration")
 
     -- ------------------------------------------------------------------ --
     -- Phase 1: WALK Pikachu from slot 0

--- a/test/tests/test_walking_pokemon_return.lua
+++ b/test/tests/test_walking_pokemon_return.lua
@@ -1,0 +1,191 @@
+-------------------------------------------------------------------------------
+-- test_walking_pokemon_return.lua
+--
+-- Regression test for issue #4: walking-pokemon RETURN must follow the
+-- Pokemon by identity (species+PID), not party slot index.
+--
+-- Bug: after a party SWITCH that moves the walking Pokemon to a new slot,
+-- the stale sFollower.partySlot caused RETURN to appear on the wrong slot
+-- and the actual follower to lose its RETURN option entirely.
+--
+-- Full flow:
+--   1. Boot to overworld. Inject Pikachu (slot 0) + Meowth (slot 1).
+--   2. Open party menu -> WALK Pikachu.
+--      Check: sFollower.active==1, sFollower.species==25.
+--   3. Open party menu -> SWITCH Pikachu (slot 0) with Meowth (slot 1).
+--      Check: sFollower.active still 1.
+--   4. Open party menu -> slot 1 (Pikachu's new position) -> option [1].
+--      After fix: option [1] = RETURN -> follower deactivates.
+--      Before fix: option [1] = SWITCH -> sub-menu opens; B backs out; follower stays.
+--      Check: sFollower.active==0.
+--   5. Open party menu -> WALK Meowth (slot 0).
+--      Check: sFollower.active==1, sFollower.species==52.
+--
+-- Run:
+--   bash test/run_test.sh test/tests/test_walking_pokemon_return.lua
+--
+-- Record:
+--   bash test/record_test.sh test/tests/test_walking_pokemon_return.lua
+-------------------------------------------------------------------------------
+
+local script_dir = debug.getinfo(1, "S").source:match("@?(.*/)") or ""
+local project_dir = script_dir .. "../../"
+local fw   = dofile(project_dir .. "test/lib/framework.lua")
+local cs   = dofile(project_dir .. "test/lib/character_select.lua")
+local ADDR = dofile(project_dir .. "test/lib/addresses.lua")
+
+local STATE_PATH   = "/tmp/pokefirered-walking-pokemon.ss"
+local PARTY_BASE   = 0x02024284  -- gPlayerParty (from pokefirered.map)
+local POKEMON_SIZE = 100         -- sizeof(struct Pokemon)
+
+-- sFollower field offsets defined in test/lib/addresses.lua
+local FOLLOWER_ACTIVE  = ADDR.sFollower + ADDR.FOLLOWER_OFF_ACTIVE
+local FOLLOWER_SPECIES = ADDR.sFollower + ADDR.FOLLOWER_OFF_SPECIES  -- u16
+
+local SPECIES_PIKACHU = 25
+local SPECIES_MEOWTH  = 52
+
+-- Write a minimal valid Pokemon into party memory at `base`.
+-- Uses PID=0, OTID=0 so XOR encryption key = PID XOR OTID = 0 (no encryption).
+-- Substruct order = PID % 24 = 0 = [Growth, Attacks, EVs, Misc].
+-- Growth.species is the first u16 of the secure block (BoxPokemon+0x20).
+local function inject_pokemon(base, species, level)
+    for i = 0, POKEMON_SIZE - 1 do emu:write8(base + i, 0) end
+    emu:write8(base + 0x13, 0x02)                       -- hasSpecies flag
+    emu:write8(base + 0x55, 0xFF)                       -- no mail
+    emu:write8(base + 0x20, species % 256)              -- Growth.species low
+    emu:write8(base + 0x21, math.floor(species / 256))  -- Growth.species high
+    emu:write8(base + 0x1C, species % 256)              -- checksum low
+    emu:write8(base + 0x1D, math.floor(species / 256))  -- checksum high
+    emu:write8(base + 0x54, level)                      -- level
+    emu:write8(base + 0x56, 20)                         -- currentHP
+    emu:write8(base + 0x58, 20)                         -- maxHP
+end
+
+local results = {}
+-- check() logs PASS/FAIL but does not set a non-zero shell exit code on failure.
+-- This matches the convention used by all tests in this project (see test_pc_anywhere.lua).
+local function check(name, cond)
+    results[#results + 1] = {name = name, pass = cond}
+    fw.log((cond and "[PASS] " or "[FAIL] ") .. name)
+end
+
+fw.run(function()
+    fw.log("=== Walking Pokemon Return Fix Test ===")
+
+    -- ------------------------------------------------------------------ --
+    -- Fixture: boot to overworld with Pikachu+Meowth, save state
+    -- ------------------------------------------------------------------ --
+    if not fw.try_load_state(STATE_PATH) then
+        fw.log("No cached state — booting through Oak's speech...")
+        local sel = cs.find_selection_press()
+        if not sel then
+            fw.log("ERROR: character select discovery failed — aborting")
+            fw.finish()
+            return
+        end
+        emu:reset()
+        cs.boot_and_open_list(sel)
+        cs.confirm_and_enter_overworld()
+        fw.log("Reached overworld. Injecting Pikachu + Meowth...")
+
+        inject_pokemon(PARTY_BASE,                SPECIES_PIKACHU, 5)
+        inject_pokemon(PARTY_BASE + POKEMON_SIZE, SPECIES_MEOWTH,  5)
+        emu:write8(ADDR.gPlayerPartyCount, 2)
+
+        -- Set FLAG_SYS_POKEMON_GET (0x828) so Start menu shows POKEMON.
+        -- byte index = 0x828/8 = 0x105, bit = 0
+        local sb1 = fw.read32(ADDR.gSaveBlock1Ptr)
+        local flag_addr = sb1 + ADDR.SB1_FLAGS + math.floor(0x828 / 8)
+        emu:write8(flag_addr, fw.read8(flag_addr) | 0x01)
+        fw.wait_frames(30)
+        fw.save_state(STATE_PATH)
+    end
+    fw.wait_frames(60)
+
+    -- ------------------------------------------------------------------ --
+    -- Phase 1: WALK Pikachu from slot 0
+    -- Action menu for slot 0 (Pikachu, eligible, no follower):
+    --   [0] SUMMARY  [1] WALK  [2] SWITCH  [3] ITEM  [4] MOVE TO PC  [5] CANCEL
+    -- ------------------------------------------------------------------ --
+    fw.log("--- Phase 1: WALK Pikachu (slot 0) ---")
+    fw.press("START"); fw.wait_frames(80)
+    fw.press("A");     fw.wait_frames(120)  -- open party menu
+    fw.press("A");     fw.wait_frames(80)   -- open slot 0 action menu
+    fw.press("DOWN");  fw.wait_frames(20)   -- move to [1] WALK
+    fw.press("A");     fw.wait_frames(120)  -- select WALK; returns to overworld
+
+    check("Phase 1: follower active after WALK",
+          fw.read8(FOLLOWER_ACTIVE) == 1)
+    check("Phase 1: follower species is Pikachu",
+          fw.read16(FOLLOWER_SPECIES) == SPECIES_PIKACHU)
+
+    -- ------------------------------------------------------------------ --
+    -- Phase 2: SWITCH Pikachu (slot 0) with Meowth (slot 1)
+    -- Action menu for slot 0 (Pikachu, IS follower, active):
+    --   [0] SUMMARY  [1] RETURN  [2] SWITCH  [3] ITEM  [4] MOVE TO PC  [5] CANCEL
+    -- After SWITCH: Meowth is at slot 0, Pikachu is at slot 1.
+    -- ------------------------------------------------------------------ --
+    fw.log("--- Phase 2: SWITCH Pikachu to slot 1 ---")
+    fw.press("START"); fw.wait_frames(80)
+    fw.press("A");     fw.wait_frames(120)  -- open party menu
+    fw.press("A");     fw.wait_frames(80)   -- open slot 0 action menu (Pikachu)
+    fw.press("DOWN");  fw.wait_frames(20)   -- to [1] RETURN
+    fw.press("DOWN");  fw.wait_frames(20)   -- to [2] SWITCH
+    fw.press("A");     fw.wait_frames(60)   -- enter SWITCH mode
+    fw.press("DOWN");  fw.wait_frames(20)   -- move cursor to slot 1
+    fw.press("A");     fw.wait_frames(80)   -- confirm swap; party now swapped
+    fw.press("B");     fw.wait_frames(80)   -- close party menu
+    fw.press("B");     fw.wait_frames(30)   -- close start menu if still open
+
+    check("Phase 2: follower still active after SWITCH",
+          fw.read8(FOLLOWER_ACTIVE) == 1)
+
+    -- ------------------------------------------------------------------ --
+    -- Phase 3: RETURN Pikachu from slot 1 (its new position)
+    -- After fix — slot 1 action menu (Pikachu identified by species+PID):
+    --   [0] SUMMARY  [1] RETURN  [2] SWITCH  [3] ITEM  [4] MOVE TO PC  [5] CANCEL
+    -- Before fix — slot 1 action menu (orphaned: follower is "not here" by slot):
+    --   [0] SUMMARY  [1] SWITCH  [2] ITEM  [3] MOVE TO PC  [4] CANCEL
+    --   Pressing [1] opens SWITCH sub-menu; pressing B backs out; active stays 1.
+    -- ------------------------------------------------------------------ --
+    fw.log("--- Phase 3: RETURN Pikachu from slot 1 ---")
+    fw.press("START"); fw.wait_frames(80)
+    fw.press("A");     fw.wait_frames(120)  -- open party menu
+    fw.press("DOWN");  fw.wait_frames(20)   -- cursor to slot 1
+    fw.press("A");     fw.wait_frames(80)   -- open slot 1 action menu
+    fw.press("DOWN");  fw.wait_frames(20)   -- to option [1] (RETURN after fix)
+    fw.press("A");     fw.wait_frames(120)  -- select it; returns to overworld if RETURN
+    -- If SWITCH fired instead (pre-fix bug), back out of any sub-menus
+    fw.press("B");     fw.wait_frames(30)
+    fw.press("B");     fw.wait_frames(30)
+    fw.press("B");     fw.wait_frames(30)
+
+    check("Phase 3: follower deactivated by RETURN",
+          fw.read8(FOLLOWER_ACTIVE) == 0)
+
+    -- ------------------------------------------------------------------ --
+    -- Phase 4: WALK Meowth from slot 0 (its new position after swap)
+    -- Action menu for slot 0 (Meowth, eligible, no follower active):
+    --   [0] SUMMARY  [1] WALK  [2] SWITCH  [3] ITEM  [4] MOVE TO PC  [5] CANCEL
+    -- ------------------------------------------------------------------ --
+    fw.log("--- Phase 4: WALK Meowth (slot 0) ---")
+    fw.press("START"); fw.wait_frames(80)
+    fw.press("A");     fw.wait_frames(120)  -- open party menu
+    fw.press("A");     fw.wait_frames(80)   -- open slot 0 action menu (Meowth)
+    fw.press("DOWN");  fw.wait_frames(20)   -- to [1] WALK
+    fw.press("A");     fw.wait_frames(120)  -- select WALK; returns to overworld
+
+    check("Phase 4: follower active after WALK Meowth",
+          fw.read8(FOLLOWER_ACTIVE) == 1)
+    check("Phase 4: follower species is Meowth",
+          fw.read16(FOLLOWER_SPECIES) == SPECIES_MEOWTH)
+
+    -- ------------------------------------------------------------------ --
+    -- Report
+    -- ------------------------------------------------------------------ --
+    local passed = 0
+    for _, r in ipairs(results) do if r.pass then passed = passed + 1 end end
+    fw.log(string.format("Results: %d/%d passed", passed, #results))
+    fw.finish()
+end)


### PR DESCRIPTION
## Summary

Fixes #4 — the RETURN option in the party menu for a walking Pokemon was tied to `sFollower.partySlot`, a slot index that goes stale after the player uses SWITCH to rearrange the party.

**Root cause:** After a SWITCH, `sFollower.partySlot` still points to the original slot (e.g. slot 0), but the walking Pokemon is now in a different slot (e.g. slot 1). `SetPartyMonFieldSelectionActions` compared `slotId == GetFollowerPartySlot()` to decide which slot gets the RETURN option — so it would show RETURN on the wrong slot (or not at all if the original slot is now empty).

**Fix:** Added a `u32 pid` field to the `sFollower` EWRAM struct. `ActivateFollower` now stores the Pokemon's personality value (PID) alongside its species. A new `IsFollowerPokemon(struct Pokemon *mon)` function checks both species and PID to identify the walking Pokemon by identity rather than position. `SetPartyMonFieldSelectionActions` now calls `IsFollowerPokemon(&mons[slotId])` instead of comparing slot indices.

Species+PID makes the identity check robust: a 32-bit PID combined with species gives ~1-in-700M collision odds between two live party members of the same species.

## Changes

- **`src/pokemon_follower.c`**: Added `u32 pid` to `sFollower` struct; store/clear it in `ActivateFollower`/`DeactivateFollower`; added `IsFollowerPokemon()`.
- **`include/pokemon_follower.h`**: Declared `IsFollowerPokemon`.
- **`src/party_menu.c`**: Replaced stale slot-index check with `IsFollowerPokemon(&mons[slotId])`; hoisted `u16 species` declaration for C89 compliance.
- **`test/lib/addresses.lua`**: Added `sFollower` EWRAM address section; corrected downstream roaming addresses (+4 bytes from struct growth).
- **`test/tests/test_walking_pokemon_return.lua`**: New regression test — WALK Pikachu → SWITCH to slot 1 → RETURN from slot 1 → WALK Meowth → verify Meowth species. **6/6 checks pass.**
- **`test/record_test.sh`**: Made virtual display configurable via `${X_DISPLAY:-:1}`.

## Test

```
bash test/run_test.sh test/tests/test_walking_pokemon_return.lua
```

All 6 checks pass. Recording: `/tmp/mgba-recordings/test_walking_pokemon_return_20260426_162648.mp4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)