### PR TITLE
Fix #2: Replace follower teleport with catch-up run movement

### DIFF
--- a/src/pokemon_follower.c
+++ b/src/pokemon_follower.c
@@ -67,6 +67,14 @@
 #define DEVIATE_CHANCE  4
 
 /*
+ * STUCK_FRAMES: how many consecutive blocked catch-up moves before falling
+ * back to teleport. A move is "blocked" if the follower's tile coordinate
+ * does not change after a held movement completes (the ObjectEvent faced the
+ * target direction but geometry prevented the step).
+ */
+#define STUCK_FRAMES    5
+
+/*
  * All follower state lives in EWRAM. Persists across map warps (EWRAM is
  * not cleared between maps) but resets on game load (EWRAM is zeroed at
  * boot). This means the follower is session-only: it does not survive
@@ -76,9 +84,12 @@ static EWRAM_DATA struct {
     bool8 active;           /* Follower is logically enabled */
     bool8 spriteSpawned;    /* Sprite currently exists on screen */
     u8 partySlot;           /* Index into gPlayerParty[] */
+    u8 stuckFrames;         /* Consecutive catch-up moves with no position change */
     u16 species;            /* Cached species (for change detection) */
     u8 graphicsId;          /* OBJ_EVENT_GFX_* constant for the sprite */
     u8 objEventId;          /* Index into gObjectEvents[] */
+    s16 prevX;              /* Follower X before last catch-up move (stuck detection) */
+    s16 prevY;              /* Follower Y before last catch-up move (stuck detection) */
 } sFollower = {0};
 
 /*
@@ -515,7 +526,7 @@ void UpdateFollowerPokemon(void)
 {
     struct ObjectEvent *playerObj;
     struct ObjectEvent *followerObj;
-    s16 dx, dy, dist;
+    s16 dx, dy, dist, absDx, absDy;
     u8 moveDir;
 
     if (!sFollower.active || !sFollower.spriteSpawned)
@@ -540,12 +551,46 @@ void UpdateFollowerPokemon(void)
     dy = playerObj->currentCoords.y - followerObj->currentCoords.y;
     dist = (dx < 0 ? -dx : dx) + (dy < 0 ? -dy : dy);
 
-    /* Too far away — teleport to catch up */
+    /* Too far away — catch-up mode: move directly toward player without randomness.
+     * No IDLE_CHANCE skip, no DEVIATE_CHANCE deviation. Uses the run animation
+     * (GetWalkFastMovementAction) so the follower visually hurries.
+     *
+     * Stuck detection: if the follower's position did not change since the last
+     * catch-up move (geometry blocked it), increment stuckFrames. After
+     * STUCK_FRAMES consecutive blocked moves, fall back to teleport so the
+     * follower cannot get permanently trapped. */
     if (dist > TELEPORT_DIST)
     {
-        TeleportFollowerNearPlayer(followerObj, playerObj);
+        if (followerObj->currentCoords.x == sFollower.prevX &&
+            followerObj->currentCoords.y == sFollower.prevY)
+            sFollower.stuckFrames++;
+        else
+            sFollower.stuckFrames = 0;
+
+        if (sFollower.stuckFrames >= STUCK_FRAMES)
+        {
+            TeleportFollowerNearPlayer(followerObj, playerObj);
+            sFollower.stuckFrames = 0;
+            sFollower.prevX = followerObj->currentCoords.x;
+            sFollower.prevY = followerObj->currentCoords.y;
+            return;
+        }
+
+        absDx = dx < 0 ? -dx : dx;
+        absDy = dy < 0 ? -dy : dy;
+        if (absDx > absDy || (absDx == absDy && (Random() & 1)))
+            moveDir = (dx > 0) ? DIR_EAST : DIR_WEST;
+        else
+            moveDir = (dy > 0) ? DIR_SOUTH : DIR_NORTH;
+
+        sFollower.prevX = followerObj->currentCoords.x;
+        sFollower.prevY = followerObj->currentCoords.y;
+        ObjectEventSetHeldMovement(followerObj, GetWalkFastMovementAction(moveDir));
         return;
     }
+
+    /* Back within TELEPORT_DIST — reset catch-up state */
+    sFollower.stuckFrames = 0;
 
     /* Close enough — just idle near the player */
     if (dist <= FOLLOW_DIST)

--- a/test/lib/addresses.lua
+++ b/test/lib/addresses.lua
@@ -396,7 +396,7 @@ ADDR.gPlayerPartyCount               = 0x02024029
 --
 -- NOTE: Verify FOLLOWER_BASE from pokefirered.map after any rebuild that
 -- adds new EWRAM symbols, as the EWRAM layout can shift.
-ADDR.FOLLOWER_BASE             = 0x0203f7ac
+ADDR.FOLLOWER_BASE             = 0x0203f7a8
 ADDR.FOLLOWER_OBJ_EVENT_ID_OFF = 0x07
 
 -- ObjectEvent previousCoords offsets (layout mirrors currentCoords at 0x10/0x12).

--- a/test/lib/addresses.lua
+++ b/test/lib/addresses.lua
@@ -379,4 +379,30 @@ ADDR.ITEM_MAX_ELIXIR                 = 37
 
 ADDR.gPlayerPartyCount               = 0x02024029
 
+-------------------------------------------------------------------------------
+-- FOLLOWER STATE
+-- sFollower is a static EWRAM_DATA struct in src/pokemon_follower.c.
+-- Address from pokefirered.map (ewram_data section of pokemon_follower.o).
+-- Struct layout after patch (12 bytes total):
+--   offset 0: bool8 active
+--   offset 1: bool8 spriteSpawned
+--   offset 2: u8 partySlot
+--   offset 3: u8 stuckFrames  (catch-up stuck counter)
+--   offset 4: u16 species
+--   offset 6: u8 graphicsId
+--   offset 7: u8 objEventId   <- FOLLOWER_OBJ_EVENT_ID_OFF
+--   offset 8: s16 prevX       (position before last catch-up move)
+--   offset 10: s16 prevY
+--
+-- NOTE: Verify FOLLOWER_BASE from pokefirered.map after any rebuild that
+-- adds new EWRAM symbols, as the EWRAM layout can shift.
+ADDR.FOLLOWER_BASE             = 0x0203f7ac
+ADDR.FOLLOWER_OBJ_EVENT_ID_OFF = 0x07
+
+-- ObjectEvent previousCoords offsets (layout mirrors currentCoords at 0x10/0x12).
+-- Used to write both coord fields atomically when repositioning the follower
+-- in tests, preventing the movement system from seeing a stale prev position.
+ADDR.OE_PREV_X = 0x14
+ADDR.OE_PREV_Y = 0x16
+
 return ADDR

--- a/test/tests/test_follower_catchup.lua
+++ b/test/tests/test_follower_catchup.lua
@@ -1,0 +1,197 @@
+-------------------------------------------------------------------------------
+-- test_follower_catchup.lua
+--
+-- Regression test for GitHub issue #2: follower Pokemon must not teleport
+-- when it falls more than TELEPORT_DIST (5) tiles behind the player. Instead
+-- it must move step-by-step (catch-up mode) using the run animation.
+--
+-- WHAT IT TESTS:
+-- We place the follower 8 tiles from the player (> TELEPORT_DIST = 5), then
+-- run the game for 300 frames and assert that no single frame sees the
+-- follower's tile coordinate jump by more than 1 in either axis. A jump > 1
+-- indicates a teleport. We also assert the follower eventually catches up
+-- (final dist <= FOLLOW_DIST = 2).
+--
+-- FIXTURE STATE (self-healing):
+-- On first run, the test boots through Oak's speech, injects Pikachu into
+-- party slot 0, sets FLAG_SYS_POKEMON_GET, navigates the party menu to
+-- activate WALK (spawning the follower sprite), and saves a state to
+-- /tmp/pokefirered-follower-catchup.ss. Subsequent runs reuse this fixture.
+-- Delete the .ss file to force recreation after a ROM rebuild.
+--
+-- HOW TO RUN:
+--   bash test/run_test.sh test/tests/test_follower_catchup.lua
+-------------------------------------------------------------------------------
+
+local script_dir = debug.getinfo(1, "S").source:match("@?(.*/)") or ""
+local project_dir = script_dir .. "../../"
+local fw   = dofile(project_dir .. "test/lib/framework.lua")
+local cs   = dofile(project_dir .. "test/lib/character_select.lua")
+local ADDR = dofile(project_dir .. "test/lib/addresses.lua")
+
+local STATE_PATH   = "/tmp/pokefirered-follower-catchup.ss"
+local PARTY_BASE   = 0x02024284  -- gPlayerParty (from pokefirered.map)
+local POKEMON_SIZE = 100         -- sizeof(struct Pokemon)
+local SPECIES_PIKACHU = 25       -- Pokedex #25
+
+-- Write a minimal valid Pikachu into party memory at `base`.
+-- PID=0, OTID=0 -> XOR key=0, substruct order 0=GAEM (no decryption needed).
+-- Checksum = sum of all 24 u16s of secure.raw = species (only non-zero u16).
+local function inject_pikachu(base)
+    local species = SPECIES_PIKACHU
+    for i = 0, POKEMON_SIZE - 1 do emu:write8(base + i, 0) end
+    emu:write8(base + 0x13, 0x02)                             -- hasSpecies flag
+    emu:write8(base + 0x55, 0xFF)                             -- no mail
+    emu:write8(base + 0x20, species % 256)                    -- species lo (Growth)
+    emu:write8(base + 0x21, math.floor(species / 256))        -- species hi
+    emu:write8(base + 0x1C, species % 256)                    -- checksum lo
+    emu:write8(base + 0x1D, math.floor(species / 256))        -- checksum hi
+    emu:write8(base + 0x54, 5)                                -- level
+    emu:write8(base + 0x56, 20)                               -- currentHP lo
+    emu:write8(base + 0x58, 20)                               -- maxHP lo
+end
+
+-- Read the follower's current tile position from gObjectEvents.
+local function read_follower_pos()
+    local oeid = fw.read8(ADDR.FOLLOWER_BASE + ADDR.FOLLOWER_OBJ_EVENT_ID_OFF)
+    local oa   = ADDR.gObjectEvents + oeid * ADDR.OBJECT_EVENT_SIZE
+    return fw.read16(oa + ADDR.OE_CURRENT_X),
+           fw.read16(oa + ADDR.OE_CURRENT_Y),
+           oeid
+end
+
+-- Read the player's current tile position.
+local function read_player_pos()
+    local oeid = fw.read8(ADDR.gPlayerAvatar + ADDR.PA_OBJECT_EVENT_ID)
+    local oa   = ADDR.gObjectEvents + oeid * ADDR.OBJECT_EVENT_SIZE
+    return fw.read16(oa + ADDR.OE_CURRENT_X),
+           fw.read16(oa + ADDR.OE_CURRENT_Y)
+end
+
+fw.run(function()
+    fw.log("=== Test: Follower catch-up without teleport (Issue #2) ===")
+
+    -- ------------------------------------------------------------------ --
+    -- Fixture: self-healing setup                                         --
+    -- ------------------------------------------------------------------ --
+    if not fw.try_load_state(STATE_PATH) then
+        fw.log("Fixture not found. Running full setup...")
+
+        -- Boot through Oak's speech and character selection.
+        local sel = cs.find_selection_press()
+        if not sel then
+            fw.log_error("character select discovery failed")
+            fw.finish()
+            return
+        end
+        emu:reset()
+        cs.boot_and_open_list(sel)
+        cs.confirm_and_enter_overworld()
+        fw.log("In overworld. Injecting Pikachu...")
+
+        inject_pikachu(PARTY_BASE)
+        emu:write8(ADDR.gPlayerPartyCount, 1)
+
+        -- Set FLAG_SYS_POKEMON_GET (0x828) so POKEMON appears first in the
+        -- Start menu. Flag byte: 0x828>>3 = 0x105, bit: 0x828&7 = 0.
+        local sb1      = fw.read32(ADDR.gSaveBlock1Ptr)
+        local flag_off = math.floor(0x828 / 8)   -- 0x105
+        local flag_bit = 0x828 % 8               -- 0
+        local flag_addr = sb1 + ADDR.SB1_FLAGS + flag_off
+        emu:write8(flag_addr, fw.read8(flag_addr) | (1 << flag_bit))
+        fw.wait_frames(30)
+
+        -- Open Start menu -> POKEMON (first entry with only POKEMON flag set) -> party menu.
+        fw.press("START")
+        fw.wait_frames(50)
+        fw.press("A")          -- select POKEMON
+        fw.wait_frames(80)
+
+        -- Party menu: Pikachu is in slot 0 (default cursor). Open action menu.
+        fw.press("A")
+        fw.wait_frames(50)
+
+        -- Action menu order for Pikachu: SUMMARY (0), WALK (1).
+        -- WALK appears because CanSpeciesFollowPlayer(PIKACHU) is TRUE and no
+        -- follower is active yet.
+        fw.press("DOWN")       -- cursor to WALK
+        fw.wait_frames(10)
+        fw.press("A")          -- activate WALK -> ActivateFollower called
+        fw.wait_frames(200)    -- wait for menu close + SpawnFollowerSprite
+
+        -- Verify follower spawned (objEventId must be a valid slot index < 16).
+        local _, _, foeid = read_follower_pos()
+        fw.log(string.format("Follower objEventId after WALK: %d", foeid))
+        if foeid >= ADDR.OBJECT_EVENTS_COUNT then
+            fw.log_error("Follower sprite did not spawn after selecting WALK")
+            fw.finish()
+            return
+        end
+
+        fw.save_state(STATE_PATH)
+        fw.log("Fixture saved: " .. STATE_PATH)
+    end
+
+    fw.wait_frames(60)   -- let state settle after load
+
+    -- ------------------------------------------------------------------ --
+    -- Position follower 8 tiles right of player (dist=8 > TELEPORT_DIST=5)
+    -- ------------------------------------------------------------------ --
+    local px, py = read_player_pos()
+    fw.log(string.format("Player at (%d, %d)", px, py))
+
+    local _, _, foeid = read_follower_pos()
+    fw.log(string.format("Follower objEventId: %d", foeid))
+
+    if foeid >= ADDR.OBJECT_EVENTS_COUNT then
+        fw.log_error("Follower not active in fixture state")
+        fw.finish()
+        return
+    end
+
+    local target_x = px + 8
+    fw.log(string.format("Placing follower at (%d, %d) — 8 tiles right of player", target_x, py))
+    local foa = ADDR.gObjectEvents + foeid * ADDR.OBJECT_EVENT_SIZE
+    -- Write both currentCoords and previousCoords so the ObjectEvent has a
+    -- consistent internal state (TeleportFollowerNearPlayer sets both fields).
+    emu:write16(foa + ADDR.OE_CURRENT_X, target_x)
+    emu:write16(foa + ADDR.OE_CURRENT_Y, py)
+    emu:write16(foa + ADDR.OE_PREV_X,    target_x)
+    emu:write16(foa + ADDR.OE_PREV_Y,    py)
+
+    fw.wait_frames(2)   -- let UpdateFollowerPokemon see the new distance
+
+    -- ------------------------------------------------------------------ --
+    -- Monitor for 300 frames: assert no single-frame jump > 1 tile       --
+    -- A jump > 1 means TeleportFollowerNearPlayer was called.             --
+    -- Coords are read as unsigned u16 but Pallet bedroom tiles are small
+    -- positive values, so no s16 sign-extension ambiguity arises here.   --
+    -- ------------------------------------------------------------------ --
+    local teleport_detected = false
+    local prev_fx, prev_fy = read_follower_pos()
+
+    for i = 1, 300 do
+        fw.yield()
+        local cur_fx, cur_fy = read_follower_pos()
+        local jump_x = math.abs(cur_fx - prev_fx)
+        local jump_y = math.abs(cur_fy - prev_fy)
+        if jump_x > 1 or jump_y > 1 then
+            fw.log_error(string.format(
+                "Frame %d: teleport! follower (%d,%d) -> (%d,%d) (jump %d,%d)",
+                i, prev_fx, prev_fy, cur_fx, cur_fy, jump_x, jump_y))
+            teleport_detected = true
+            break
+        end
+        prev_fx, prev_fy = cur_fx, cur_fy
+    end
+
+    fw.assert_true(not teleport_detected, "follower did not teleport during 300-frame catch-up")
+
+    -- After catch-up, verify the follower actually arrived near the player.
+    local final_fx, final_fy = read_follower_pos()
+    local final_dist = math.abs(final_fx - px) + math.abs(final_fy - py)
+    fw.log(string.format("Final follower dist from player: %d tiles", final_dist))
+    fw.assert_true(final_dist <= 2, "follower caught up within FOLLOW_DIST=2")
+
+    fw.finish()
+end)


### PR DESCRIPTION
## Summary

- Removes instant teleport when follower Pokémon falls > 5 tiles behind the player
- Adds **catch-up mode**: direct run movement toward player, no idle/deviation randomness
- Keeps teleport as last-resort fallback after 5 consecutive geometry-blocked moves
- Organic following behaviour (idle + deviation) unchanged for medium distance (2–5 tiles)

## Implementation

**`src/pokemon_follower.c`:**
- Added `STUCK_FRAMES = 5` constant
- Added `stuckFrames` (u8), `prevX` (s16), `prevY` (s16) fields to `sFollower` struct — `stuckFrames` fills a pre-existing padding byte so no existing field offsets change
- `UpdateFollowerPokemon`: replaces the single-line `TeleportFollowerNearPlayer` call with a catch-up block that uses `GetWalkFastMovementAction` and detects stuck-on-geometry via position comparison

**`test/tests/test_follower_catchup.lua`** (new):
- Self-healing fixture: injects Pikachu, navigates party menu to activate WALK
- Positions follower 8 tiles from player, monitors 300 frames asserting no jump > 1 tile
- Passed 2/2

## Test plan

- [x] `bash test/run_test.sh test/tests/test_follower_catchup.lua` → 2/2 PASS
- [x] Build clean: `make -j$(nproc) firered`
- [x] `FOLLOWER_BASE` verified from `pokefirered.map` after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)